### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ But, the only file you need is the resource, which you can get from `jsdelivr`_:
 
 .. code-block:: html
 
-    <script type="text/javascript" src="//cdn.jsdelivr.net/porterjs/1.1.3/porter.min.js"></script>
+    <script type="text/javascript" src="//cdn.jsdelivr.net/npm/porterjs-framework@1.1.3/bin/porter.min.js"></script>
 
 So, feel free to just link that one file.
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/porterjs-framework.

Feel free to ping me if you have any questions regarding this change.